### PR TITLE
Fix: Resolve Tailwind CSS integration issues

### DIFF
--- a/.postcssrc.json
+++ b/.postcssrc.json
@@ -1,5 +1,6 @@
 {
   "plugins": {
-    "@tailwindcss/postcss": {}
+    "@tailwindcss/postcss": {},
+    "autoprefixer": {}
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: ['./src/**/*.{html,ts}'],
   theme: {
     extend: {},


### PR DESCRIPTION
This commit addresses issues preventing Tailwind CSS from functioning correctly.

The following changes were made:
- Modified `tailwind.config.ts` to use ES module syntax (`export default`) for compatibility with the project's module system.
- Updated the PostCSS configuration (`.postcssrc.json`) to include `autoprefixer`, ensuring proper vendor prefixing for CSS rules.
- I ran commands to update dependencies and to confirm the changes.